### PR TITLE
Avoid overwriting an existing .bit file

### DIFF
--- a/bin/init.js
+++ b/bin/init.js
@@ -9,6 +9,10 @@ const createKey = function() {
 }
 module.exports = function() {
   let _path = process.cwd() + "/.bit"
+  if (fs.existsSync(_path)) {
+    console.log("Bitcom already initiated. Use a folder with no .bit file.")
+    return;
+  }
   let stream = fs.createWriteStream(_path)
   let keys = createKey()
   stream.once('open', function(fd) {


### PR DESCRIPTION
Reinitiating `bit init` should be idempotent so that an existing .bit does not accidentally gets overwritten with new content.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unwriter/bitcom/5)
<!-- Reviewable:end -->
