### PR TITLE
Add bitcom as alias for the bit command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "./node_modules/mocha/bin/mocha"
   },
   "bin": {
-    "bit": "./index.js"
+    "bit": "./index.js",
+    "bitcom": "./index.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Not important, but a service for people who dont use the bitcom command `bit` too often. 

If you think is not clean to have two commands for the same thing just reject the PR.